### PR TITLE
Update instructions for prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Quick start options:
 
 - Buy from [Creative Tim](https://www.creative-tim.com/product/vision-ui-dashboard-react?ref=readme-vudreact).
 
-## Terminal Commands
+## Preparation
 
-1. Download and Install NodeJs LTS version from [NodeJs Official Page](https://nodejs.org/en/download/).
-2. Navigate to the root / directory and run yarn install/npm install to install our local dependencies.
+1. Download and Install NodeJs 16 from the [official website](https://nodejs.org/en/about/previous-releases) or use [nvm](https://github.com/nvm-sh/nvm) to quickly switch versions.
+2. Navigate to the projects root directory and run `yarn install` or `npm install` to install the projects dependencies.
 
 ## Documentation
 


### PR DESCRIPTION
This PR clarifies instructions. E.g., the project works with Node 16 but not with LTS 18 and newer node versions.

rendered preview: https://github.com/ttytm/vision-ui-dashboard-react/tree/docs/update-prep-instructions#preparation